### PR TITLE
Add mouse input support

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         match terminal.poll_event(&[], &[], Some(Duration::from_millis(100)))? {
             Some(TerminalEvent::Input(input)) => {
-                let TerminalInput::Key(input) = input;
+                let TerminalInput::Key(input) = input else {
+                    continue;  // Skip mouse events
+                };
 
                 // Check if 'q' was pressed
                 if let tuinix::KeyCode::Char('q') = input.code {

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -27,7 +27,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     loop {
         match terminal.poll_event(&[], &[], Some(Duration::from_millis(100)))? {
             Some(TerminalEvent::Input(input)) => {
-                let TerminalInput::Key(input) = input;
+                let TerminalInput::Key(input) = input else {
+                    continue; // Skip mouse events
+                };
 
                 // Check if 'q' was pressed
                 if let tuinix::KeyCode::Char('q') = input.code {

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -1,0 +1,201 @@
+use std::{fmt::Write, time::Duration};
+
+use tuinix::{Terminal, TerminalColor, TerminalEvent, TerminalFrame, TerminalInput, TerminalStyle};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize terminal
+    let mut terminal = Terminal::new()?;
+
+    // Create a frame with the terminal's dimensions
+    let mut frame: TerminalFrame = TerminalFrame::new(terminal.size());
+
+    // Add styled content to the frame
+    let title_style = TerminalStyle::new().bold();
+    let info_style = TerminalStyle::new().underline();
+
+    writeln!(
+        frame,
+        "{}Mouse Input Demo{}",
+        title_style,
+        TerminalStyle::RESET
+    )?;
+    writeln!(
+        frame,
+        "\n{}Instructions:{}",
+        info_style,
+        TerminalStyle::RESET
+    )?;
+    writeln!(frame, "• Click anywhere to see mouse events")?;
+    writeln!(frame, "• Try left, right, and middle mouse buttons")?;
+    writeln!(frame, "• Try scrolling with the mouse wheel")?;
+    writeln!(frame, "• Press 'q' to quit")?;
+    writeln!(
+        frame,
+        "\n{}Last mouse event: None{}",
+        info_style,
+        TerminalStyle::RESET
+    )?;
+
+    // Draw the initial frame to the terminal
+    terminal.draw(frame)?;
+
+    // Process input events with a timeout
+    loop {
+        match terminal.poll_event(&[], &[], Some(Duration::from_millis(100)))? {
+            Some(TerminalEvent::Input(input)) => {
+                match input {
+                    TerminalInput::Key(key_input) => {
+                        // Check if 'q' was pressed
+                        if let tuinix::KeyCode::Char('q') = key_input.code {
+                            break;
+                        }
+
+                        // Display the key input
+                        let mut frame: TerminalFrame = TerminalFrame::new(terminal.size());
+                        writeln!(
+                            frame,
+                            "{}Mouse Input Demo{}",
+                            title_style,
+                            TerminalStyle::RESET
+                        )?;
+                        writeln!(
+                            frame,
+                            "\n{}Instructions:{}",
+                            info_style,
+                            TerminalStyle::RESET
+                        )?;
+                        writeln!(frame, "• Click anywhere to see mouse events")?;
+                        writeln!(frame, "• Try left, right, and middle mouse buttons")?;
+                        writeln!(frame, "• Try scrolling with the mouse wheel")?;
+                        writeln!(frame, "• Press 'q' to quit")?;
+                        writeln!(
+                            frame,
+                            "\n{}Last event: Key pressed: {:?}{}",
+                            info_style,
+                            key_input,
+                            TerminalStyle::RESET
+                        )?;
+                        terminal.draw(frame)?;
+                    }
+                    TerminalInput::Mouse(mouse_input) => {
+                        // Display the mouse input with detailed information
+                        let mut frame: TerminalFrame = TerminalFrame::new(terminal.size());
+                        writeln!(
+                            frame,
+                            "{}Mouse Input Demo{}",
+                            title_style,
+                            TerminalStyle::RESET
+                        )?;
+                        writeln!(
+                            frame,
+                            "\n{}Instructions:{}",
+                            info_style,
+                            TerminalStyle::RESET
+                        )?;
+                        writeln!(frame, "• Click anywhere to see mouse events")?;
+                        writeln!(frame, "• Try left, right, and middle mouse buttons")?;
+                        writeln!(frame, "• Try scrolling with the mouse wheel")?;
+                        writeln!(frame, "• Press 'q' to quit")?;
+
+                        // Format mouse event details
+                        let event_style =
+                            TerminalStyle::new().bold().fg_color(TerminalColor::GREEN);
+                        writeln!(
+                            frame,
+                            "\n{}Mouse Event Details:{}",
+                            event_style,
+                            TerminalStyle::RESET
+                        )?;
+                        writeln!(frame, "  Event: {:?}", mouse_input.event)?;
+                        writeln!(
+                            frame,
+                            "  Position: column {}, row {}",
+                            mouse_input.col, mouse_input.row
+                        )?;
+
+                        // Show modifiers if any are pressed
+                        let mut modifiers = Vec::new();
+                        if mouse_input.ctrl {
+                            modifiers.push("Ctrl");
+                        }
+                        if mouse_input.alt {
+                            modifiers.push("Alt");
+                        }
+                        if mouse_input.shift {
+                            modifiers.push("Shift");
+                        }
+
+                        if !modifiers.is_empty() {
+                            writeln!(frame, "  Modifiers: {}", modifiers.join(" + "))?;
+                        } else {
+                            writeln!(frame, "  Modifiers: None")?;
+                        }
+
+                        // Add event-specific information
+                        match mouse_input.event {
+                            tuinix::MouseEvent::LeftPress => {
+                                writeln!(frame, "  → Left button pressed")?
+                            }
+                            tuinix::MouseEvent::LeftRelease => {
+                                writeln!(frame, "  → Left button released")?
+                            }
+                            tuinix::MouseEvent::RightPress => {
+                                writeln!(frame, "  → Right button pressed")?
+                            }
+                            tuinix::MouseEvent::RightRelease => {
+                                writeln!(frame, "  → Right button released")?
+                            }
+                            tuinix::MouseEvent::MiddlePress => {
+                                writeln!(frame, "  → Middle button pressed")?
+                            }
+                            tuinix::MouseEvent::MiddleRelease => {
+                                writeln!(frame, "  → Middle button released")?
+                            }
+                            tuinix::MouseEvent::Drag => writeln!(frame, "  → Mouse dragged")?,
+                            tuinix::MouseEvent::Move => writeln!(frame, "  → Mouse moved")?,
+                            tuinix::MouseEvent::ScrollUp => writeln!(frame, "  → Scrolled up")?,
+                            tuinix::MouseEvent::ScrollDown => writeln!(frame, "  → Scrolled down")?,
+                        }
+
+                        terminal.draw(frame)?;
+                    }
+                }
+            }
+            Some(TerminalEvent::Resize(size)) => {
+                // Terminal was resized, update UI
+                let mut frame: TerminalFrame = TerminalFrame::new(size);
+                writeln!(
+                    frame,
+                    "{}Mouse Input Demo{}",
+                    title_style,
+                    TerminalStyle::RESET
+                )?;
+                writeln!(
+                    frame,
+                    "\n{}Instructions:{}",
+                    info_style,
+                    TerminalStyle::RESET
+                )?;
+                writeln!(frame, "• Click anywhere to see mouse events")?;
+                writeln!(frame, "• Try left, right, and middle mouse buttons")?;
+                writeln!(frame, "• Try scrolling with the mouse wheel")?;
+                writeln!(frame, "• Press 'q' to quit")?;
+                writeln!(
+                    frame,
+                    "\n{}Terminal resized to {}x{}{}",
+                    info_style,
+                    size.cols,
+                    size.rows,
+                    TerminalStyle::RESET
+                )?;
+                terminal.draw(frame)?;
+            }
+            Some(TerminalEvent::FdReady { .. }) => unreachable!(),
+            None => {
+                // Timeout elapsed, no events to process
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -113,7 +113,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                         writeln!(
                             frame,
                             "  Position: column {}, row {}",
-                            mouse_input.col, mouse_input.row
+                            mouse_input.position.col, mouse_input.position.row
                         )?;
 
                         // Show modifiers if any are pressed

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -155,7 +155,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                                 writeln!(frame, "  → Middle button released")?
                             }
                             tuinix::MouseEvent::Drag => writeln!(frame, "  → Mouse dragged")?,
-                            tuinix::MouseEvent::Move => writeln!(frame, "  → Mouse moved")?,
                             tuinix::MouseEvent::ScrollUp => writeln!(frame, "  → Scrolled up")?,
                             tuinix::MouseEvent::ScrollDown => writeln!(frame, "  → Scrolled down")?,
                         }

--- a/examples/mouse.rs
+++ b/examples/mouse.rs
@@ -6,6 +6,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize terminal
     let mut terminal = Terminal::new()?;
 
+    // Enable mouse input reporting
+    terminal.enable_mouse_input()?;
+
     // Create a frame with the terminal's dimensions
     let mut frame: TerminalFrame = TerminalFrame::new(terminal.size());
 

--- a/examples/nonblocking.rs
+++ b/examples/nonblocking.rs
@@ -66,20 +66,20 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 STDIN_TOKEN => {
                     // Handle keyboard input
                     while let Some(Some(input)) = try_nonblocking(terminal.read_input())? {
-                        match input {
-                            TerminalInput::Key(key_input) => {
-                                // Check if 'q' was pressed
-                                if let KeyCode::Char('q') = key_input.code {
-                                    return Ok(());
-                                }
+                        let TerminalInput::Key(key_input) = input else {
+                            continue; // Skip mouse events
+                        };
 
-                                // Display the input
-                                let mut frame: TerminalFrame = TerminalFrame::new(terminal.size());
-                                writeln!(frame, "Key pressed: {key_input:?}")?;
-                                writeln!(frame, "\nPress any key ('q' to quit)")?;
-                                terminal.draw(frame)?;
-                            }
+                        // Check if 'q' was pressed
+                        if let KeyCode::Char('q') = key_input.code {
+                            return Ok(());
                         }
+
+                        // Display the input
+                        let mut frame: TerminalFrame = TerminalFrame::new(terminal.size());
+                        writeln!(frame, "Key pressed: {key_input:?}")?;
+                        writeln!(frame, "\nPress any key ('q' to quit)")?;
+                        terminal.draw(frame)?;
                     }
                 }
                 SIGNAL_TOKEN => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,7 @@ mod terminal;
 
 pub use frame::{EstimateCharWidth, FixedCharWidthEstimator, TerminalFrame};
 pub use geometry::{TerminalPosition, TerminalRegion, TerminalSize};
-pub use input::{KeyCode, KeyInput, TerminalInput};
+pub use input::{KeyCode, KeyInput, MouseEvent, MouseInput, TerminalInput};
 pub use style::{TerminalColor, TerminalStyle};
 pub use terminal::{Terminal, TerminalEvent};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,9 @@
 //!     loop {
 //!         match terminal.poll_event(&[], &[], Some(Duration::from_millis(100)))? {
 //!             Some(TerminalEvent::Input(input)) => {
-//!                 let TerminalInput::Key(input) = input;
+//!                 let TerminalInput::Key(input) = input else {
+//!                     continue;  // Skip mouse events
+//!                 };
 //!
 //!                 // Check if 'q' was pressed
 //!                 if let tuinix::KeyCode::Char('q') = input.code {

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -254,7 +254,8 @@ impl Terminal {
     ///     if let Some(event) = terminal.poll_event(&[], &[], Some(Duration::from_millis(100)))? {
     ///         match event {
     ///             TerminalEvent::Input(TerminalInput::Mouse(mouse)) => {
-    ///                 println!("Mouse event: {:?} at ({}, {})", mouse.event, mouse.col, mouse.row);
+    ///                 println!("Mouse event: {:?} at ({}, {})",
+    ///                          mouse.event, mouse.position.col, mouse.position.row);
     ///             }
     ///             _ => {}
     ///         }


### PR DESCRIPTION
- **Add mouse input support with X10/X11 and SGR mouse mode parsing**
- **Replace pattern matching with let-else to skip mouse events in input handling**
- **Add mouse input example demonstrating mouse events and input handling**
- **Add mouse input support with enable/disable methods and cleanup on drop**
- **Remove MouseEvent::Move variant and improve mouse input parsing**
- **Refactor mouse input parsing: optimize loop iteration, fix drag event logic, and add comprehensive tests**
- **Refactor terminal input parser by extracting functions and improving code organization**
- **Refactor X10 mouse input parsing to handle modifier bits and improve button code detection**
- **Refactor MouseInput to use TerminalPosition for coordinates**
